### PR TITLE
Making minishell work with linux

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,125 @@
+# Language (LanguageKind)
+# Language, this format style is targeted at.
+# LK_Cpp (in configuration: Cpp) Should be used for C, C++, ObjectiveC, ObjectiveC++.
+Language: Cpp
+
+# TabWidth (unsigned)
+# The number of columns used for tab stops.
+TabWidth: 4
+
+# IndentWidth (unsigned)
+# The number of columns to use for indentation.
+IndentWidth: 4
+
+# TODO: If it can be enabled with tabs instead of spaces, it can fit 42 norm.
+# AlignConsecutiveDeclarations (bool)
+# If true, aligns consecutive declarations.
+# Ex)
+# int         aaaa = 12;
+# float       b = 23;
+# std::string ccc = 23;
+# AlignConsecutiveDeclarations: false
+
+# UseTab (UseTabStyle)
+# The way to use tab characters in the resulting file.
+# UT_ForContinuationAndIndentation (in configuration: ForContinuationAndIndentation) Use tabs only for line continuation and indentation.
+# UT_Always (in configuration: Always) Use ta into a single line.
+AllowShortFunctionsOnASingleLine: None
+
+# Options for aligning backslashes in escaped newlines.
+# ENAS_Left (in configuration: Left) Align escaped newlines as far left as possible.
+AlignEscapedNewlines: Left
+
+# Dependent on the value, while (true) { continue; } can be put on a single line.
+# SBS_Never (in configuration: Never) Never merge blocks into a single line.
+AllowShortBlocksOnASingleLine: Never
+
+# If true, if (a) return; can be put on a single line.
+# SIS_Never (in configuration: Never) Never put short ifs on the same line.
+AllowShortIfStatementsOnASingleLine: Never
+
+# AlwaysBreakAfterDefinitionReturnType (DefinitionReturnTypeBreakingStyle)
+# The function definition return type breaking style to use. This option is deprecated and is retained for backwards compatibility.
+# DRTBS_None (in configuration: None) Break after return type automatically. PenaltyReturnTypeOnItsOwnLine is taken into account.
+AlwaysBreakAfterReturnType: None
+
+# AlwaysBreakBeforeMultilineStrings (bool)
+# If true, always break before multiline string literals.
+AlwaysBreakBeforeMultilineStrings: false
+
+# BinPackArguments (bool)
+# If false, a function call’s arguments will either be all on the same line or will have one line each.
+BinPackArguments: false
+
+# BinPackParameters (bool)
+# If false, a function declaration’s or function definition’s parameters will either all be on the same line or will have one line each.
+BinPackParameters: false
+
+# BreakBeforeBraces (BraceBreakingStyle)
+# The brace breaking style to use.
+# BS_Allman (in configuration: Allman) Always break before braces.
+BreakBeforeBraces: Allman
+
+# BreakBeforeTernaryOperators (bool)
+# If true, ternary operators will be placed after line breaks.
+BreakBeforeTernaryOperators: true
+
+# ColumnLimit (unsigned)
+# The column limit.
+ColumnLimit: 1024
+
+# FixNamespaceComments (bool)
+# If true, clang-format adds missing namespace end comments and fixes invalid existing ones.
+# FixNamespaceComments: false
+
+# IncludeBlocks (IncludeBlocksStyle)
+# Dependent on the value, multiple #include blocks can be sorted as one and divided based on category.
+# IBS_Merge (in configuration: Merge) Merge multiple #include blocks together and sort as one.
+IncludeBlocks: Merge
+
+# KeepEmptyLinesAtTheStartOfBlocks (bool)
+# If true, the empty line at the start of blocks is kept.
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+# MaxEmptyLinesToKeep (unsigned)
+# The maximum number of consecutive empty lines to keep.
+MaxEmptyLinesToKeep: 1
+
+# PointerAlignment (PointerAlignmentStyle)
+# Pointer and reference alignment style.
+# PAS_Right (in configuration: Right) Align pointer to the right.
+PointerAlignment: Right
+
+# PenaltyBreakBeforeFirstCallParameter (unsigned)
+# The penalty for breaking a function call after call(.
+PenaltyBreakBeforeFirstCallParameter: 1
+
+# PenaltyBreakString (unsigned)
+# The penalty for each line break introduced inside a string literal.
+PenaltyBreakString: 1
+
+# PenaltyExcessCharacter (unsigned)
+# The penalty for each character outside of the column limit.
+PenaltyExcessCharacter: 10
+
+PenaltyReturnTypeOnItsOwnLine: 100
+
+# SpaceAfterCStyleCast (bool)
+# If true, a space is inserted after C style casts.
+SpaceAfterCStyleCast: false
+
+# SpaceBeforeAssignmentOperators (bool)
+# If false, spaces will be removed before assignment operators.
+SpaceBeforeAssignmentOperators: true
+
+# SpaceBeforeSquareBrackets (bool)
+# Ibs whenever we need to fill whitespace that spans at least from one tab stop to the next one.
+UseTab: ForContinuationAndIndentation
+
+# SpaceBeforeParens (SpaceBeforeParensOptions)
+# Defines in which cases to put a space before opening parentheses.
+# SBPO_ControlStatements (in configuration: ControlStatements) Put a space before opening parentheses only after control statement keywords (for/if/while...).
+SpaceBeforeParens: ControlStatements
+# AllowShortFunctionsOnASingleLine (ShortFunctionStyle)
+# Dependent on the value, int f() { return 0; } can be put on a single line.
+# SFS_None (in configuration: None) Never

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-export LIBRARY_PATH = $(HOME)/.brew/lib
-export C_INCLUDE_PATH = $(HOME)/.brew/Cellar/criterion/2.4.1_2/include
+# Exports for MacOs, that needs readline from homebrew to work:
 # export LIBRARY_PATH = $(HOME)/homebrew/lib
 # export C_INCLUDE_PATH = $(HOME)/homebrew/Cellar/criterion/2.4.1_2/include
 

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -10,84 +10,76 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "shell.h"
 #include "libft.h"
+#include "shell.h"
 
-static int	check_last_tok(t_token **token_list);
+static int check_last_tok(t_token **token_list);
 
-t_token	**tokenize(t_shell *shell)
-{
-	t_token	**tok_list;
-	char	*trimmed;
-	int		status;
+t_token **tokenize(t_shell *shell) {
+  t_token **tok_list;
+  char *trimmed;
+  int status;
 
-	trimmed = ft_strtrim(shell->input, " ");
-	if (!trimmed)
-		return (NULL);
-	tok_list = ft_calloc(1, sizeof(t_token *));
-	if (!tok_list)
-		return (free(trimmed), NULL);
-	status = create_tok_list(trimmed, &tok_list, shell);
-	if (status == 1)
-		return (free(trimmed), clean_tokens(tok_list), NULL);
-	else if (status == 2)
-	{
-		print_error_and_set_status("syntax error", 258);
-		return (free(trimmed), clean_tokens(tok_list), NULL);
-	}
-	if (join_tokens(*tok_list) == ERROR)
-	{
-		print_error_and_set_status("syntax error", 258);
-		return (free(trimmed), clean_tokens(tok_list), NULL);
-	}
-	*tok_list = remove_white_space(*tok_list);
-	return (free(trimmed), tok_list);
+  trimmed = ft_strtrim(shell->input, " ");
+  if (!trimmed)
+    return (NULL);
+  tok_list = ft_calloc(1, sizeof(t_token *));
+  if (!tok_list)
+    return (free(trimmed), NULL);
+  status = create_tok_list(trimmed, &tok_list, shell);
+  if (status == 1)
+    return (free(trimmed), clean_tokens(tok_list), NULL);
+  else if (status == 2) {
+    print_error_and_set_status("syntax error", 258);
+    return (free(trimmed), clean_tokens(tok_list), NULL);
+  }
+  if (join_tokens(*tok_list) == ERROR) {
+    print_error_and_set_status("syntax error", 258);
+    return (free(trimmed), clean_tokens(tok_list), NULL);
+  }
+  *tok_list = remove_white_space(*tok_list);
+  return (free(trimmed), tok_list);
 }
 
-t_token	*create_tok(long long start, long long end, char *str)
-{
-	t_token	*tok;
-	char	*tok_string;
+t_token *create_tok(long long start, long long end, char *str) {
+  t_token *tok;
+  char *tok_string;
 
-	tok_string = ft_substr(str, start, end - start);
-	if (!tok_string)
-		return (NULL);
-	tok = ft_new_token(tok_string);
-	if (!tok)
-		return (free(tok_string), NULL);
-	return (tok);
+  tok_string = ft_substr(str, start, end - start);
+  if (!tok_string)
+    return (NULL);
+  tok = ft_new_token(tok_string);
+  if (!tok)
+    return (free(tok_string), NULL);
+  return (tok);
 }
 
-int	expand_tok(t_token *tok, t_token **token_list, t_shell *sh)
-{
-	if ((tok->token_id == ENV_VAR || tok->token_id == D_QUOTE) && \
-								check_last_tok(token_list) == 0)
-	{
-		if (tok->token_id == D_QUOTE)
-		{
-			if (check_quotes_tok(tok) == ERROR)
-				return (free(tok), free(tok->content), 1);
-			if (remove_enclosing_quotes(tok) == ERROR)
-				return (free(tok), free(tok->content), 1);
-		}
-		tok->content = expand_double_quotes(tok, sh->env_list);
-		if (!tok->content)
-			return (free(tok), 1);
-		tok->token_id = WORD;
-	}
-	return (0);
+int expand_tok(t_token *tok, t_token **token_list, t_shell *sh) {
+  if ((tok->token_id == ENV_VAR || tok->token_id == D_QUOTE) &&
+      check_last_tok(token_list) == 0) {
+    if (tok->token_id == D_QUOTE) {
+      if (check_quotes_tok(tok) == ERROR)
+        return (free(tok->content), free(tok), 1);
+      if (remove_enclosing_quotes(tok) == ERROR)
+        return (free(tok->content), free(tok), 1);
+    }
+    tok->content = expand_double_quotes(tok, sh->env_list);
+    if (!tok->content)
+      return (free(tok), 1);
+    tok->token_id = WORD;
+  }
+  return (0);
 }
 
-static int	check_last_tok(t_token **token_list)
-{
-	t_token	*last_token;
+static int check_last_tok(t_token **token_list) {
+  t_token *last_token;
 
-	if (!*token_list)
-		return (0);
-	last_token = *token_list;
-	while (last_token->next != NULL)
-		last_token = last_token->next;
-	if (last_token->token_id == HEREDOC)
-		return (1);
-	return (0);
+  if (!*token_list)
+    return (0);
+  last_token = *token_list;
+  while (last_token->next != NULL)
+    last_token = last_token->next;
+  if (last_token->token_id == HEREDOC)
+    return (1);
+  return (0);
 }

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -15,71 +15,78 @@
 
 static int check_last_tok(t_token **token_list);
 
-t_token **tokenize(t_shell *shell) {
-  t_token **tok_list;
-  char *trimmed;
-  int status;
+t_token **tokenize(t_shell *shell)
+{
+	t_token **tok_list;
+	char *trimmed;
+	int status;
 
-  trimmed = ft_strtrim(shell->input, " ");
-  if (!trimmed)
-    return (NULL);
-  tok_list = ft_calloc(1, sizeof(t_token *));
-  if (!tok_list)
-    return (free(trimmed), NULL);
-  status = create_tok_list(trimmed, &tok_list, shell);
-  if (status == 1)
-    return (free(trimmed), clean_tokens(tok_list), NULL);
-  else if (status == 2) {
-    print_error_and_set_status("syntax error", 258);
-    return (free(trimmed), clean_tokens(tok_list), NULL);
-  }
-  if (join_tokens(*tok_list) == ERROR) {
-    print_error_and_set_status("syntax error", 258);
-    return (free(trimmed), clean_tokens(tok_list), NULL);
-  }
-  *tok_list = remove_white_space(*tok_list);
-  return (free(trimmed), tok_list);
+	trimmed = ft_strtrim(shell->input, " ");
+	if (!trimmed)
+		return (NULL);
+	tok_list = ft_calloc(1, sizeof(t_token *));
+	if (!tok_list)
+		return (free(trimmed), NULL);
+	status = create_tok_list(trimmed, &tok_list, shell);
+	if (status == 1)
+		return (free(trimmed), clean_tokens(tok_list), NULL);
+	else if (status == 2)
+	{
+		print_error_and_set_status("syntax error", 258);
+		return (free(trimmed), clean_tokens(tok_list), NULL);
+	}
+	if (join_tokens(*tok_list) == ERROR)
+	{
+		print_error_and_set_status("syntax error", 258);
+		return (free(trimmed), clean_tokens(tok_list), NULL);
+	}
+	*tok_list = remove_white_space(*tok_list);
+	return (free(trimmed), tok_list);
 }
 
-t_token *create_tok(long long start, long long end, char *str) {
-  t_token *tok;
-  char *tok_string;
+t_token *create_tok(long long start, long long end, char *str)
+{
+	t_token *tok;
+	char *tok_string;
 
-  tok_string = ft_substr(str, start, end - start);
-  if (!tok_string)
-    return (NULL);
-  tok = ft_new_token(tok_string);
-  if (!tok)
-    return (free(tok_string), NULL);
-  return (tok);
+	tok_string = ft_substr(str, start, end - start);
+	if (!tok_string)
+		return (NULL);
+	tok = ft_new_token(tok_string);
+	if (!tok)
+		return (free(tok_string), NULL);
+	return (tok);
 }
 
-int expand_tok(t_token *tok, t_token **token_list, t_shell *sh) {
-  if ((tok->token_id == ENV_VAR || tok->token_id == D_QUOTE) &&
-      check_last_tok(token_list) == 0) {
-    if (tok->token_id == D_QUOTE) {
-      if (check_quotes_tok(tok) == ERROR)
-        return (free(tok->content), free(tok), 1);
-      if (remove_enclosing_quotes(tok) == ERROR)
-        return (free(tok->content), free(tok), 1);
-    }
-    tok->content = expand_double_quotes(tok, sh->env_list);
-    if (!tok->content)
-      return (free(tok), 1);
-    tok->token_id = WORD;
-  }
-  return (0);
+int expand_tok(t_token *tok, t_token **token_list, t_shell *sh)
+{
+	if ((tok->token_id == ENV_VAR || tok->token_id == D_QUOTE) && check_last_tok(token_list) == 0)
+	{
+		if (tok->token_id == D_QUOTE)
+		{
+			if (check_quotes_tok(tok) == ERROR)
+				return (free(tok->content), free(tok), 1);
+			if (remove_enclosing_quotes(tok) == ERROR)
+				return (free(tok->content), free(tok), 1);
+		}
+		tok->content = expand_double_quotes(tok, sh->env_list);
+		if (!tok->content)
+			return (free(tok), 1);
+		tok->token_id = WORD;
+	}
+	return (0);
 }
 
-static int check_last_tok(t_token **token_list) {
-  t_token *last_token;
+static int check_last_tok(t_token **token_list)
+{
+	t_token *last_token;
 
-  if (!*token_list)
-    return (0);
-  last_token = *token_list;
-  while (last_token->next != NULL)
-    last_token = last_token->next;
-  if (last_token->token_id == HEREDOC)
-    return (1);
-  return (0);
+	if (!*token_list)
+		return (0);
+	last_token = *token_list;
+	while (last_token->next != NULL)
+		last_token = last_token->next;
+	if (last_token->token_id == HEREDOC)
+		return (1);
+	return (0);
 }


### PR DESCRIPTION
- Fixed order of frees in return statements in tokenizer.c
- Added .clang-format for easy autoformating according to 42 norm. (src: https://github.com/dawnbeen/c_formatter_42/blob/master/c_formatter_42/data/.clang-format)
- Removed redundant lines from makefile